### PR TITLE
Add generic method for api calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,26 +1,27 @@
 {
-    "name": "squeezenode-lordpengwin",
-    "author": "Piotr Raczynski <pio[dot]raczynski[at]gmail[dot]com>",
-    "version": "0.0.9",
-    "description": "Node.js wrapper library for squeezebox CLI/json interface with Spotify/SoundCloud support",
-    "main": "server.js",
-    "keywords": [
-        "squeezebox",
-        "logitechmediaserver",
-        "spotify",
-        "soundcloud",
-        "jsonrpc",
-        "remote",
-        "smarthome",
-        "home automation"
-    ],
-    "dependencies": {
-        "jayson": "1.1.3",
-        "super" : "0.2.3",
-        "request" : "2.51.0"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/piotrraczynski/squeezenode.git"
-    }
+  "name": "squeezenode-lordpengwin",
+  "author": "Piotr Raczynski <pio[dot]raczynski[at]gmail[dot]com>",
+  "version": "0.0.9",
+  "description": "Node.js wrapper library for squeezebox CLI/json interface with Spotify/SoundCloud support",
+  "main": "server.js",
+  "keywords": [
+    "squeezebox",
+    "logitechmediaserver",
+    "spotify",
+    "soundcloud",
+    "jsonrpc",
+    "remote",
+    "smarthome",
+    "home automation"
+  ],
+  "dependencies": {
+    "jayson": "1.1.3",
+    "lodash": "^4.17.4",
+    "request": "2.51.0",
+    "super": "0.2.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/piotrraczynski/squeezenode.git"
+  }
 }


### PR DESCRIPTION
### What 

This adds a generic `callMethod` function to the SqueezePlayer object. This way you can use any of the LMS API methods without needing to explicitly define a proxy function in squeezeplayer.js (e.g, `this.clearPlaylist, this.setVolume` etc). This adds a lot of flexibility and power to squeezenode since we now have easier access to all the API methods. 

You could make the argument that this is unnecessary because we could always just use the SqueezeRequest request function directly. That's true, but I think this provides a nice abstraction away from the SqueezeRequest object. Plus, the code is much clearer when using `callMethod`. 

Take the following example:  
```js
myPlayer.callMethod({
    method: 'playlists',
    params: [0, 2], 
});
```

vs.

```
myPlayer.request(myPlayer.playerId, ['playlists', 0, 2] callbackFunction);
```

With `callMethod` you don't need to provide the player id and the method name is much more explicit. The parameters are still kind of weird and ambiguous (what the heck does "0" and "2" mean?), but that's the fault of the LMS API. 

Plus - support for promises!!

### Testing
I used the node repl for testing. It was a pain, but it can be done. 

What do you think? 

cc: @lordpengwin @MikeDeSantis

Also, should we try to get this fork merged into @piotrraczynski's original repo? @piotrraczynski are you still maintaining that?